### PR TITLE
サインアウト機能の実装

### DIFF
--- a/src/components/Frame7.tsx
+++ b/src/components/Frame7.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { HamburgerMenuBase, FlexBox, RelativeBox, AbsoluteBox, StyledText, HoverElement, StyledDiv } from './StyledComponents';
 import HamburgerMenuButton from './HamburgerMenuButton';
 import { useHistory } from "react-router-dom";
+import firebase from '../firebase';
+import { Redirect } from 'react-router-dom';
 
 type Frame7Props = {
     closeFrame7: () => void;   
@@ -29,6 +31,17 @@ const Frame7: React.FC<Frame7Props> = (props) => {
 
     const ToSubjectList = () =>{
         history.push("/frame11")
+    }
+
+    const onClickSignOut = () => { 
+        const user = firebase.auth().currentUser;
+        if(!user) return;
+        firebase.auth().signOut().then(()=>{
+            console.log('successfully signed out.');
+            return <Redirect to='/frame1'/>
+        }).catch((error) => {
+            console.log('sign out failed.')
+        })
     }
 
     const { closeFrame7 } = props;
@@ -76,7 +89,7 @@ const Frame7: React.FC<Frame7Props> = (props) => {
                     </AbsoluteBox>
                     <AbsoluteBox width='9em' top='98%' left='98%' translateX={-100} translateY={-100}>
                         <HoverElement backgroundColor='#d2d2d2'>
-                            <StyledText size='1.5em' isClickable={true}>
+                            <StyledText onClick={()=> {onClickSignOut()}} size='1.5em' isClickable={true}>
                                 サインアウト
                             </StyledText>
                         </HoverElement>


### PR DESCRIPTION
以下の項目を確認してください。
- クローンもしくはpull後、`.env.local`を配置、`yarn install`及び`yarn start`を実行し、ログイン画面が表示
- ブラウザ画面上で右クリック後、「検証」をクリック。出てくる画面の「Console」タブを開く。
- ログイン後、frame2においてハンバーガーメニューを開き、右下の「サインアウト」をクリック。
- 「successfully signed out.」とConsoleに表示されたのち、frame1に戻ることを確認。
- この状態でframe13やframe10など他画面に遷移しようとアドレスバーにURLを入力しても移動できないことを確認
- 再度他ユーザーでサインインし、そのほかのframe3, frame4, frame10, frame11など各画面からも同様にサインアウトできることを確認。